### PR TITLE
add proxy url from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ export GITHUB_MIGRATOR_SOURCE_API_TOKEN=xxx
 export GITHUB_MIGRATOR_SOURCE_API_ENDPOINT=http://localhost/api/v3 # This might be the endpoint of GitHub Enterprise
 export GITHUB_MIGRATOR_TARGET_API_TOKEN=yyy
 # export GITHUB_MIGRATOR_TARGET_API_ENDPOINT=https://api.github.com # No need to specify the endpoint of github.com
+# export GITHUB_MIGRATOR_TARGET_PROXY_URL=http://proxyIp:proxyPort # If you need proxy URL
 go run . [old-owner]/[source] [new-owner]/[target]
 ```
 Be sure to use this tool before pushing the git tree to the new origin (otherwise the links in the merged commits are lost).

--- a/github/client.go
+++ b/github/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/tomnomnom/linkheader"
@@ -65,12 +66,18 @@ type Client interface {
 }
 
 // New creates a new GitHub client.
-func New(token, endpoint string, opts ...ClientOption) Client {
+func New(token, endpoint string, proxy string, opts ...ClientOption) Client {
 	cli := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: endpoint != "https://api.github.com",
 		},
 	}}
+	if proxy != "" {
+		proxyURL, _ := url.Parse(proxy)
+		cli = &http.Client{Transport: &http.Transport{
+			Proxy: http.ProxyURL(proxyURL),
+		}}
+	}
 	c := &client{token, endpoint, cli, &Logger{}}
 	for _, opt := range opts {
 		opt(c)

--- a/github/client.go
+++ b/github/client.go
@@ -73,10 +73,11 @@ func New(token, endpoint, proxy string, opts ...ClientOption) Client {
 		},
 	}}
 	if proxy != "" {
-		proxyURL, _ := url.Parse(proxy)
-		cli = &http.Client{Transport: &http.Transport{
-			Proxy: http.ProxyURL(proxyURL),
-		}}
+		proxyURL, err := url.Parse(proxy)
+		if err != nil {
+			panic(err)
+		}
+		cli.Transport.(*http.Transport).Proxy = http.ProxyURL(proxyURL)
 	}
 	c := &client{token, endpoint, cli, &Logger{}}
 	for _, opt := range opts {

--- a/github/client.go
+++ b/github/client.go
@@ -66,7 +66,7 @@ type Client interface {
 }
 
 // New creates a new GitHub client.
-func New(token, endpoint string, proxy string, opts ...ClientOption) Client {
+func New(token, endpoint, proxy string, opts ...ClientOption) Client {
 	cli := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: endpoint != "https://api.github.com",

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -3,5 +3,5 @@ package github
 import "testing"
 
 func TestNew(t *testing.T) {
-	var _ Client = New("token", "http://localhost")
+	var _ Client = New("token", "http://localhost", "")
 }

--- a/main.go
+++ b/main.go
@@ -41,9 +41,6 @@ func createGitHubClient(tokenEnv, endpointEnv, proxyEnv string) (github.Client, 
 		endpoint = "https://api.github.com"
 	}
 	proxy := os.Getenv(proxyEnv)
-	if proxyEnv == "" {
-		proxy = ""
-	}
 	cli := github.New(
 		token, endpoint, proxy,
 		github.ClientLogger(

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func run(args []string) error {
 	return mig.Migrate()
 }
 
-func createGitHubClient(tokenEnv, endpointEnv string, proxyEnv string) (github.Client, error) {
+func createGitHubClient(tokenEnv, endpointEnv, proxyEnv string) (github.Client, error) {
 	token := os.Getenv(tokenEnv)
 	if token == "" {
 		return nil, fmt.Errorf("GitHub token not found (specify %s)", tokenEnv)

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func run(args []string) error {
 	return mig.Migrate()
 }
 
-func createGitHubClient(tokenEnv, endpointEnv string) (github.Client, error) {
+func createGitHubClient(tokenEnv, endpointEnv string, proxyEnv string) (github.Client, error) {
 	token := os.Getenv(tokenEnv)
 	if token == "" {
 		return nil, fmt.Errorf("GitHub token not found (specify %s)", tokenEnv)
@@ -40,8 +40,12 @@ func createGitHubClient(tokenEnv, endpointEnv string) (github.Client, error) {
 	if endpoint == "" {
 		endpoint = "https://api.github.com"
 	}
+	proxy := os.Getenv(proxyEnv)
+	if proxyEnv == "" {
+		proxy = ""
+	}
 	cli := github.New(
-		token, endpoint,
+		token, endpoint, proxy,
 		github.ClientLogger(
 			github.NewLogger(
 				github.LoggerPreRequest(func(req *http.Request) {
@@ -73,6 +77,7 @@ func createMigrator(sourcePath, targetPath string) (migrator.Migrator, error) {
 	sourceCli, err := createGitHubClient(
 		"GITHUB_MIGRATOR_SOURCE_API_TOKEN",
 		"GITHUB_MIGRATOR_SOURCE_API_ENDPOINT",
+		"GITHUB_MIGRATOR_SOURCE_PROXY_URL",
 	)
 	if err != nil {
 		return nil, err
@@ -80,6 +85,7 @@ func createMigrator(sourcePath, targetPath string) (migrator.Migrator, error) {
 	targetCli, err := createGitHubClient(
 		"GITHUB_MIGRATOR_TARGET_API_TOKEN",
 		"GITHUB_MIGRATOR_TARGET_API_ENDPOINT",
+		"GITHUB_MIGRATOR_TARGET_PROXY_URL",
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Because it need to set proxy url in order to migrate from the proxy environment.